### PR TITLE
fix for descending ordered resolutions from backend

### DIFF
--- a/incl/config.php
+++ b/incl/config.php
@@ -377,6 +377,7 @@ if($scanner_ok) {
     $length = strpos($list, "..");
     if ($length === false) {
       $resolution_list = explode("|" , $list);
+      sort($resolution_list, SORT_NUMERIC);
       $resolution_max = (int)end($resolution_list);
       $resolution_min = (int)reset($resolution_list);
     } else {


### PR DESCRIPTION
Some backend driver report the supported resolutions in descending order. This fix sorts them in ascending order before storing to device specific config file.

Here is some example of a Canon Lide 220:

> Options specific to device `genesys:libusb:001:005':
>   Scan Mode:
>     --mode Color|Gray|Lineart [Gray]
>         Selects the scan mode (e.g., lineart, monochrome, or color).
>     --source Flatbed|Transparency Adapter [inactive]
>         Selects the scan source (such as a document-feeder).
>     --preview[=(yes|no)] [no]
>         Request a preview-quality scan.
>     --depth 8|16 [8]
>         Number of bits per sample, typical values are 1 for "line-art" and 8
>         for multibit scans.
>     --resolution 4800|2400|1200|600|300|150|100|75dpi [75]
>         Sets the resolution of the scanned image.
>   Geometry:
>     -l 0..216.7mm [0]
>         Top-left x position of scan area.
>     -t 0..297.5mm [0]
>         Top-left y position of scan area.
>     -x 0..216.7mm [216.7]
>         Width of scan-area.
>     -y 0..297.5mm [297.5]
>         Height of scan-area.
>   Enhancement:
>     --custom-gamma[=(yes|no)] [no]
>         Determines whether a builtin or a custom gamma-table should be used.
>     --gamma-table 0..65535,... [inactive]
>         Gamma-correction table.  In color mode this option equally affects the
>         red, green, and blue channels simultaneously (i.e., it is an intensity
>         gamma table).
>     --red-gamma-table 0..65535,... [inactive]
>         Gamma-correction table for the red band.
>     --green-gamma-table 0..65535,... [inactive]
>         Gamma-correction table for the green band.
>     --blue-gamma-table 0..65535,... [inactive]
>         Gamma-correction table for the blue band.
>     --swdeskew[=(yes|no)] [no]
>         Request backend to rotate skewed pages digitally
>     --swcrop[=(yes|no)] [no]
>         Request backend to remove border from pages digitally
>     --swdespeck[=(yes|no)] [no]
>         Request backend to remove lone dots digitally
>     --despeck 1..9 (in steps of 1) [inactive]
>         Maximum diameter of lone dots to remove from scan
>     --swskip 0..100% (in steps of 1) [0]
>         Request driver to discard pages with low numbers of dark pixels
>     --swderotate[=(yes|no)] [no]
>         Request driver to detect and correct 90 degree image rotation
>     --brightness -100..100 (in steps of 1) [0]
>         Controls the brightness of the acquired image.
>     --contrast -100..100 (in steps of 1) [0]
>         Controls the contrast of the acquired image.
>   Extras:
>     --lamp-off-time 0..60 [15]
>         The lamp will be turned off after the given time (in minutes). A value
>         of 0 means, that the lamp won't be turned off.
>     --lamp-off-scan[=(yes|no)] [no]
>         The lamp will be turned off during scan. 
>     --threshold 0..100% (in steps of 1) [50]
>         Select minimum-brightness to get a white point
>     --threshold-curve 0..127 (in steps of 1) [50]
>         Dynamic threshold curve, from light to dark, normally 50-65
>     --disable-dynamic-lineart[=(yes|no)] [no]
>         Disable use of a software adaptive algorithm to generate lineart
>         relying instead on hardware lineart.
>     --disable-interpolation[=(yes|no)] [no]
>         When using high resolutions where the horizontal resolution is smaller
>         than the vertical resolution this disables horizontal interpolation.
>     --color-filter Red|Green|Blue [Green]
>         When using gray or lineart this option selects the used color.
>     --calibration-file <string> [inactive]
>         Specify the calibration file to use
>     --expiration-time -1..30000 (in steps of 1) [60]
>         Time (in minutes) before a cached calibration expires. A value of 0
>         means cache is not used. A negative value means cache never expires.
>   Sensors:
>   Buttons:
>     --clear-calibration
>         Clear calibration cache