### PR TITLE
Make appending to files transactional

### DIFF
--- a/incl/scan.php
+++ b/incl/scan.php
@@ -1,6 +1,7 @@
 <?php
   $lang_error=$lang[$lang_id][32];
   $error_input=0;
+  $append_finalize=array_key_exists('append_finalize', $_POST) && $_POST['append_finalize'] == "true";
 
   function scan_error(&$scan_output, &$error_input, $lang_error) {
     $scan_output="!!!!!!!! ".$lang_error." !!!!!!!!";
@@ -116,8 +117,13 @@
       $preview_images = $temp_dir."preview_".$sid.".jpg";
       $cmd_device = $SCANIMAGE." -d ".$scanner." --resolution ".$PREVIEW_DPI."dpi -l 0mm -t 0mm -x ".$MAX_SCAN_WIDTH_MM."mm -y ".$MAX_SCAN_HEIGHT_MM."mm".$cmd_mode.$cmd_brightness.$cmd_contrast.$cmd_usr_opt." | ".$PNMTOJPEG." --quality=50 > ".$preview_images;
     }
-    else if ($action_save) {
-      $file_save = $save_dir.$_POST['file_name'].".".$format;
+    else if ($action_save && $append_finalize) {
+       $path_info = pathinfo($append_file);
+       rename($append_file, $save_dir.$path_info['filename'].".".$path_info['extension']);
+    }
+    else if ($action_save && !$append_finalize) {
+      $path = ($do_append_pdf || $do_append_txt) ? $temp_dir : $save_dir;
+      $file_save = $path.$_POST['file_name'].".".$format;
       if (file_exists($file_save)) {
         $file_save=$save_dir.$_POST['file_name']." ".date("Y-m-d H.i.s",time()).".".$format;
       }
@@ -173,7 +179,7 @@
   }
 
   //merge files
-  if ($action_save && $append_file !== '') {
+  if ($action_save && $append_file !== '' && !$append_finalize) {
     $escaped_file_save = str_replace(" ", "\\ ", $file_save);
     $escaped_append_file = str_replace(" ", "\\ ", $append_file);
   

--- a/phpsane.php
+++ b/phpsane.php
@@ -304,12 +304,15 @@
     
 ////////////////////////////////////////////////////////
 //////extend scanned document with another page
-<?php if ($action_save && (($format == "pdf" && $do_append_pdf) || ($format == "txt" && $do_append_txt))) {
+<?php if ($action_save && !$append_finalize && (($format == "pdf" && $do_append_pdf) || ($format == "txt" && $do_append_txt))) {
   echo "
-      if(confirm('{$lang[$lang_id][50]}')) {
-        $('#append_file').val('{$file_save}');
-        $('#tab_menu_buttons_accept').click();
-      }";
+      $('#append_file').val('{$file_save}');
+
+      if(!confirm('{$lang[$lang_id][50]}')) {
+        $('#append_finalize').val('true');
+      }
+
+      $('#tab_menu_buttons_accept').click();";
 } ?>
 
 ////////////////////////////////////////////////////////
@@ -325,7 +328,8 @@ echo "<form id='menuForm' action='phpsane.php' method='POST'>
   <input type=hidden name='lang_id' id='lang_id' value='$lang_id'>
   <input type=hidden name='sid' value='$sid'>
   <input type=hidden name='preview_images' value='$preview_images'>
-  <input type=hidden name='append_file' id='append_file' value=''>\n";
+  <input type=hidden name='append_file' id='append_file' value=''>
+  <input type=hidden name='append_finalize' id='append_finalize' value=''>\n";
 if(!$do_file_name) {
   $filename = ($file_name_prefix !== -1 ? $file_name_prefix : $lang[$lang_id][60]) . date("Y-m-d H.i.s", time());
   echo "  <input type=hidden name='file_name' id='file_name' value='$filename'>\n";


### PR DESCRIPTION
Hi,

I use php-sane along with https://www.mayan-edms.com/ to scan documents, using the [watch folder](https://docs.mayan-edms.com/topics/adding_documents.html) feature.

I encountered the problem that, when scanning multi-page (appended) documents, it's very possible that Mayan will pick up a partially completed document, and also delete the source. This is because php-sane appends to the document in the output folder.

So, in order to fix this, I've changed this so that instead of scanning final documents into the output directory, it instead scans and appends into the tmp directory. Then, when the user stops appending files the compiled file is moved to the output directory.

This means that multi-page documents are "transactional", so to speak.

Not the prettiest implementation, but it works!